### PR TITLE
Add support for totals and improvements to table formatting

### DIFF
--- a/pbs/estiname-size.py
+++ b/pbs/estiname-size.py
@@ -13,6 +13,29 @@ format_json = False
 all = False
 datastore_path = "/mnt/datastore"
 
+chunk_size = 4194304
+
+column_names = ["snapshot", "filename", "new chunks", "new chunks size"]
+column_widths = [20,25,19,16]
+table_width = sum(column_widths) + len(column_widths)*3 + 1
+
+def sizeof_fmt(num, unit=None):
+    units = ("Bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB")
+    if unit:
+        i = units.index(unit)
+        num /= 1024.0 ** i
+        if i == 0:
+            return f"{int(num):3d} {units[i]}"
+        else:
+            return f"{num:3.2f} {units[i]}"
+    for i in range(0, len(units)):
+        if abs(num) < 1024.0:
+            if i == 0:
+                return f"{int(num):3d} {units[i]}"
+            else:
+                return f"{num:3.2f} {units[i]}"
+        num /= 1024.0
+    return f"{num:.2f} YiB"
 
 def scan_vmid(datastore, vmid, all):
     if not vmid:
@@ -34,9 +57,9 @@ def scan_vmid(datastore, vmid, all):
         if format_json:
             snapshots = {}
         else:
-            print("-" * 98)
-            print(f"| {'snapshot'.ljust(20)} | {'filename'.ljust(30)} | {'new chunks'.ljust(19)} | {'new chunks size'.ljust(16)} |")
-            print("-" * 98)
+            print("-" * table_width)
+            print(f"| {column_names[0].ljust(column_widths[0])} | {column_names[1].ljust(column_widths[1])} | {column_names[2].ljust(column_widths[2])} | {column_names[3].ljust(column_widths[3])} |")
+            print("-" * table_width)
         chunkarray = set()
 
         totals = {"new_chunks": 0, "new_chunks_bytes": 0}
@@ -65,25 +88,24 @@ def scan_vmid(datastore, vmid, all):
                     new_chunks = 0
                 else:
                     continue
-
                 if format_json:
                     if snapshot in snapshots:
                         images = snapshots[snapshot]
                     else:
                         images = []
                         snapshots[snapshot] = images
-                    images += [{"filename": filename, "new_chunks": new_chunks, "new_chunks_bytes": new_chunks * 4194304}]
+                    images += [{"filename": filename, "new_chunks": new_chunks, "new_chunks_bytes": new_chunks * chunk_size}]
                 else:
-                    print(f"| {snapshot.ljust(20)} | {filename.ljust(30)} | {new_chunks:>12} chunks | {new_chunks * 4:>12.2f} MiB |")
+                    print(f"| {snapshot.ljust(column_widths[0])} | {filename.ljust(column_widths[1])} | {(str(new_chunks) + ' chunks').rjust(column_widths[2])} | {sizeof_fmt(new_chunks * chunk_size, args.units).rjust(column_widths[3])} |")
 
                 totals["new_chunks"] += new_chunks
-                totals["new_chunks_bytes"] += new_chunks * 4194304
+                totals["new_chunks_bytes"] += new_chunks * chunk_size
         if format_json:
             return {"snapshots": snapshots, "totals": totals}
         else:
-            print("-" * 98)
-            print(f"| {'TOTAL'.ljust(20)} | {''.ljust(30)} | {totals['new_chunks']:>12} chunks | {totals['new_chunks'] * 4:>12.2f} MiB |")
-            print("-" * 98)
+            print("-" * table_width)
+            print(f"| {'TOTAL'.ljust(column_widths[0])} | {''.ljust(column_widths[1])} | {(str(totals['new_chunks']) + ' chunks').rjust(column_widths[2])} | {sizeof_fmt(totals['new_chunks_bytes'], args.units).rjust(column_widths[3])} |")
+            print("-" * table_width)
 
     return None
 
@@ -99,7 +121,10 @@ if __name__ == "__main__":
     parser.add_argument('-a', '--all', action='store_const',
                     const=True, default=False,
                     help='show snapshots and images that have no new chunks')
-
+    parser.add_argument('-u', '--units', type=str, default=None,
+                        choices=["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB"],
+                        help='Specify the units for size output')
+    
     args = parser.parse_args()
 
     format_json = args.json

--- a/pbs/estiname-size.py
+++ b/pbs/estiname-size.py
@@ -39,6 +39,8 @@ def scan_vmid(datastore, vmid, all):
             print("-" * 86)
         chunkarray = set()
 
+        totals = {"new_chunks": 0, "new_chunks_bytes": 0}
+
         for filepath in filearray:
             snapshot = os.path.basename(os.path.dirname(filepath))
             filename = os.path.basename(filepath)
@@ -72,10 +74,15 @@ def scan_vmid(datastore, vmid, all):
                         snapshots[snapshot] = images
                     images += [{"filename": filename, "new_chunks": new_chunks, "new_chunks_bytes": new_chunks * 4194304}]
                 else:
-                    print(f"| {snapshot.ljust(20)} | {filename.ljust(18)} | {new_chunks:>12} chunks | {new_chunks * 4:>12} MiB |")
+                    print(f"| {snapshot.ljust(20)} | {filename.ljust(18)} | {new_chunks:>12} chunks | {new_chunks * 4:>12.2f} MiB |")
+
+                totals["new_chunks"] += new_chunks
+                totals["new_chunks_bytes"] += new_chunks * 4194304
         if format_json:
-            return snapshots
+            return {"snapshots": snapshots, "totals": totals}
         else:
+            print("-" * 86)
+            print(f"| {'TOTAL'.ljust(20)} | {''.ljust(18)} | {totals['new_chunks']:>12} chunks | {totals['new_chunks'] * 4:>12.2f} MiB |")
             print("-" * 86)
 
     return None
@@ -116,10 +123,10 @@ if __name__ == "__main__":
     for vmid in vmids_list:
         if not format_json:
             print("vmid = %s" % vmid)
-        snapshots = scan_vmid(datastore_path, vmid, all)
+        result = scan_vmid(datastore_path, vmid, all)
 
         if format_json:
-            vmids += [{"vmid": vmid, "snapshots": snapshots}]
+            vmids += [{"vmid": vmid, "totals": result["totals"], "snapshots": result["snapshots"]}]
     if format_json:
         print(json.dumps(vmids))
 

--- a/pbs/estiname-size.py
+++ b/pbs/estiname-size.py
@@ -34,9 +34,9 @@ def scan_vmid(datastore, vmid, all):
         if format_json:
             snapshots = {}
         else:
-            print("-" * 86)
-            print(f"| {'snapshot'.ljust(20)} | {'filename'.ljust(18)} | {'new chunks'.ljust(19)} | {'new chunks size'.ljust(16)} |")
-            print("-" * 86)
+            print("-" * 98)
+            print(f"| {'snapshot'.ljust(20)} | {'filename'.ljust(30)} | {'new chunks'.ljust(19)} | {'new chunks size'.ljust(16)} |")
+            print("-" * 98)
         chunkarray = set()
 
         totals = {"new_chunks": 0, "new_chunks_bytes": 0}
@@ -74,16 +74,16 @@ def scan_vmid(datastore, vmid, all):
                         snapshots[snapshot] = images
                     images += [{"filename": filename, "new_chunks": new_chunks, "new_chunks_bytes": new_chunks * 4194304}]
                 else:
-                    print(f"| {snapshot.ljust(20)} | {filename.ljust(18)} | {new_chunks:>12} chunks | {new_chunks * 4:>12.2f} MiB |")
+                    print(f"| {snapshot.ljust(20)} | {filename.ljust(30)} | {new_chunks:>12} chunks | {new_chunks * 4:>12.2f} MiB |")
 
                 totals["new_chunks"] += new_chunks
                 totals["new_chunks_bytes"] += new_chunks * 4194304
         if format_json:
             return {"snapshots": snapshots, "totals": totals}
         else:
-            print("-" * 86)
-            print(f"| {'TOTAL'.ljust(20)} | {''.ljust(18)} | {totals['new_chunks']:>12} chunks | {totals['new_chunks'] * 4:>12.2f} MiB |")
-            print("-" * 86)
+            print("-" * 98)
+            print(f"| {'TOTAL'.ljust(20)} | {''.ljust(30)} | {totals['new_chunks']:>12} chunks | {totals['new_chunks'] * 4:>12.2f} MiB |")
+            print("-" * 98)
 
     return None
 


### PR DESCRIPTION
This PR implements putting totals at the bottom of the tables and to the JSON output.

I also needed to widen the "filename" column for drive names like "drive-tpmstate0-backup" that exceeded the current width which would cause the output to become garbled. Since I was changing the column width, I made it so the column widths can be customized via a variable at the top of the script. 

Lastly I added support for automatic human-readable size conversion so it will choose the most appropriate unit e.g. KiB, MiB, GiB, TiB etc., in the output. There is also an argument -u / --units in case you want all the sizes reported in a single unit.  Adding "--units MiB" would return the script to it's original behaviour where it outputs all sizes in MiB.

#3 